### PR TITLE
Update core.json

### DIFF
--- a/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/core.json
+++ b/Libraries/SPTarkov.Server.Assets/SPT_Data/configs/core.json
@@ -180,7 +180,7 @@
                 "giveCommandEnabled": true
             },
             "commandUseLimits": {
-                "StashRows": 15
+                "StashRows": 29
             },
             "ids": {
                 "commando": "6723fd51c5924c57ce0ca01e",


### PR DESCRIPTION
Update core.json commandUseLimits for the StashRows from 15 -> 29 to now properly allow for purchasing 56 rows of stash space.